### PR TITLE
Add PostgreSQL database entities from (static) PostgreSQL clusters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3>=1.4.0
 inflection
+psycopg2
 pyyaml
 stups-tokens>=1.0.16
 zmon-cli>=1.0.49

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,0 +1,47 @@
+import pytest
+from mock import MagicMock
+
+import zmon_aws_agent.postgresql as postgresql
+
+
+def test_get_databases_from_clusters():
+    pgclusters = [
+        {
+            'id': 'test-1',
+            'dnsname': 'test-1.db.zalan.do'
+        }
+    ]
+    acc = '1234567890'
+    region = 'eu-xxx-1'
+
+    postgresql.list_postgres_databases = MagicMock()
+    postgresql.list_postgres_databases.return_value = ['db1', 'db2']
+
+    databases = postgresql.get_databases_from_clusters(pgclusters, acc, region,
+                                                       'pguser', 'pgpass')
+    assert databases == [
+        {
+            'id': 'db1-test-1.db.zalan.do[aws:1234567890:eu-xxx-1]',
+            'type': 'postgresql_database',
+            'created_by': 'agent',
+            'infrastructure_account': acc,
+            'region': region,
+            'postgresql_cluster': 'test-1',
+            'database_name': 'db1',
+            'shards': {
+                'db1': 'test-1.db.zalan.do:5432/db1'
+            }
+        },
+        {
+            'id': 'db2-test-1.db.zalan.do[aws:1234567890:eu-xxx-1]',
+            'type': 'postgresql_database',
+            'created_by': 'agent',
+            'infrastructure_account': acc,
+            'region': region,
+            'postgresql_cluster': 'test-1',
+            'database_name': 'db2',
+            'shards': {
+                'db2': 'test-1.db.zalan.do:5432/db2'
+            }
+        }
+    ]

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,4 +1,3 @@
-import pytest
 from mock import MagicMock
 
 import zmon_aws_agent.postgresql as postgresql

--- a/zmon_aws_agent/main.py
+++ b/zmon_aws_agent/main.py
@@ -173,6 +173,8 @@ def main():
             'type': 'postgresql_cluster'
         })
         postgresql_databases = postgresql.get_databases_from_clusters(postgresql_clusters,
+                                                                      infrastructure_account,
+                                                                      region,
                                                                       args.postgresql_user,
                                                                       args.postgresql_pass)
     else:

--- a/zmon_aws_agent/main.py
+++ b/zmon_aws_agent/main.py
@@ -6,10 +6,12 @@ import logging
 import json
 import requests
 import tokens
+import os
 
 from zmon_cli.client import Zmon, compare_entities
 
 import zmon_aws_agent.aws as aws
+import zmon_aws_agent.postgresql as postgresql
 
 from zmon_aws_agent.common import get_user_agent
 
@@ -85,6 +87,8 @@ def main():
     argp.add_argument('-r', '--region', dest='region', default=None)
     argp.add_argument('-j', '--json', dest='json', action='store_true')
     argp.add_argument('--no-oauth2', dest='disable_oauth2', action='store_true', default=False)
+    argp.add_argument('--postgresql-user', dest='postgresql_user', default=os.environ.get('AGENT_POSTGRESQL_USER'))
+    argp.add_argument('--postgresql-pass', dest='postgresql_pass', default=os.environ.get('AGENT_POSTGRESQL_PASS'))
     args = argp.parse_args()
 
     if not args.disable_oauth2:
@@ -162,8 +166,25 @@ def main():
 
     application_entities = aws.get_apps_from_entities(apps, infrastructure_account, region)
 
+    if args.postgresql_user and args.postgresql_pass:
+        postgresql_clusters = zmon_client.get_entities({
+            'infrastructure_account': infrastructure_account,
+            'region': region,
+            'type': 'postgresql_cluster'
+        })
+        postgresql_databases = postgresql.get_databases_from_clusters(postgresql_clusters,
+                                                                      args.postgresql_user,
+                                                                      args.postgresql_pass)
+    else:
+        # Pretend the list of DBs is empty, but also make sure we don't remove
+        # any pre-existing database entities because we don't know about them.
+        postgresql_databases = []
+        entities = [e for e in entities if e.get('type') != 'postgresql_database']
+
     current_entities = (
-        elbs + scaling_groups + apps + application_entities + rds + elasticaches + dynamodbs + certificates + sqs)
+        elbs + scaling_groups + apps + application_entities +
+        rds + postgresql_databases + elasticaches + dynamodbs +
+        certificates + sqs)
     current_entities.append(aws_limits)
     current_entities.append(ia_entity)
 

--- a/zmon_aws_agent/postgresql.py
+++ b/zmon_aws_agent/postgresql.py
@@ -1,0 +1,52 @@
+import logging
+import psycopg2
+
+
+logger = logging.getLogger(__name__)
+
+POSTGRESQL_DEFAULT_PORT = 5432
+
+
+def list_postgres_databases(*args, **kwargs):
+    logger.info("Trying to list DBs on host: {}".format(kwargs.get('host')))
+    try:
+        conn = psycopg2.connect(*args, **kwargs)
+        cur = conn.cursor()
+        cur.execute("""
+            SELECT datname
+              FROM pg_database
+             WHERE datname NOT IN('postgres', 'template0', 'template1')
+        """)
+        return [row[0] for row in cur.fetchall()]
+    except:
+        logger.exception("Failed to list DBs!")
+        return []
+
+
+def get_databases_from_clusters(pgclusters, postgresql_user, postgresql_pass):
+    entities = []
+
+    for pg in pgclusters:
+        dbnames = list_postgres_databases(host=pg['dnsname'],
+                                          port=POSTGRESQL_DEFAULT_PORT,
+                                          user=postgresql_user,
+                                          password=postgresql_pass,
+                                          dbname='postgres',
+                                          sslmode='require')
+        for db in dbnames:
+            entity = {
+                'id': '{}-{}'.format(db, pg['id']),
+                'type': 'postgresql_database',
+                'created_by': 'agent',
+                'infrastructure_account': pg['infrastructure_account'],
+                'region': pg['region'],
+
+                'postgresql_cluster': pg['id'],
+                'database_name': db,
+                'shards': {
+                    db: '{}:{}/{}'.format(pg['dnsname'], POSTGRESQL_DEFAULT_PORT, db)
+                }
+            }
+            entities.append(entity)
+
+    return entities


### PR DESCRIPTION
Listing database names requires the user and password to be provided.  These
can be given on the command line or they will be taken from the environment:
AGENT_POSTGRESQL_USER and AGENT_POSTGRESQL_PASS.

If database credentials are not specified, the agent will not add or remove
entities of type 'postgresql_database'.