### PR TITLE
Add missing package to install psycopg2 module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.opensource.zalan.do/stups/python:3.5.2-38
 
-RUN apt-get update && apt-get install -y python3-dev libffi-dev libssl-dev
+RUN apt-get update && apt-get install -y python3-dev libffi-dev libssl-dev libpq-dev
 
 COPY . /agent
 


### PR DESCRIPTION
This fixes the build of docker image.