### PR TITLE
Match EIPs against DNS names and expose the latter in entity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -756,9 +756,54 @@ def fx_launch_configuration(request):
 
 
 @pytest.fixture()
+def fx_hosted_zones(request):
+    return {'HostedZones': [
+               {'ResourceRecordSetCount': 724,
+                'Name': 'db.zalan.do.',
+                'Config': {
+                    'PrivateZone': 'false',
+                    'Comment': 'Public Hosted Zone'},
+                'CallerReference': 'sevenseconds-db.zalan.do',
+                'Id': '/hostedzone/Z1FLVOF8MF971S'}]}
+
+
+@pytest.fixture()
+def fx_hosted_zones_expected(request):
+    return ['/hostedzone/Z1FLVOF8MF971S']
+
+
+@pytest.fixture()
 def fx_launch_configuration_expected(request):
     return {'malm': 'ZW52aXJvbm1lbnQ6IHtFSVBfQUxMT0NBVElPTjogZWlwYWxsb2MtMjIzMzQ0NTV9Cg==',
             'foo-staging': 'ZW52aXJvbm1lbnQ6IHtFSVBfQUxMTzMzQ0NTV9Cg=='}
+
+
+@pytest.fixture()
+def fx_recordsets(request):
+    return {'ResourceRecordSets': [
+               {'Type': 'CNAME',
+                'Name': 'this.that.db.zalan.do.',
+                'ResourceRecords': [
+                    {'Value': 'ec2-11-22-33-44.eu-central-1.compute.amazonaws.com.'}],
+                'TTL': 600},
+               {'Type': 'CNAME',
+                'Name': 'other.cluster.co.uk.',
+                'ResourceRecords': [
+                    {'Value': 'ec2-22-33-44-55.eu-central-1.compute.amazonaws.com.'}],
+                'TTL': 600},
+               {'Type': 'CNAME',
+                'Name': 'something.interesting.com.',
+                'ResourceRecords': [
+                    {'Value': 'ec2-12-23-34-45.eu-central-1.compute.amazonaws.com.'}],
+                'TTL': 600},
+    ]}
+
+
+@pytest.fixture()
+def fx_ips_dnsnames(request):
+    return {'11.22.33.44': 'this.that.db.zalan.do',
+            '12.23.34.45': 'something.interesting.com',
+            '22.33.44.55': 'other.cluster.co.uk'}
 
 
 PG_CLUSTER = 'malm'

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -80,12 +80,12 @@ def test_collect_launch_configurations(monkeypatch, fx_launch_configuration, fx_
     asg.get_paginator.return_value.paginate.return_value.build_full_result.return_value = fx_launch_configuration
     boto = get_boto_client(monkeypatch, asg)
 
-    res = postgresql.collect_launch_configurations(conftest.pg_infrastructure_account)
+    res = postgresql.collect_launch_configurations(conftest.pg_infrastructure_account, conftest.pg_region)
 
     assert res == fx_launch_configuration_expected
 
     asg.get_paginator.assert_called_with('describe_launch_configurations')
-    boto.assert_called_with('autoscaling')
+    boto.assert_called_with('autoscaling', region_name=conftest.pg_region)
 
 
 def test_extract_eipalloc_from_lc(fx_eip_allocation, fx_launch_configuration_expected):
@@ -102,11 +102,11 @@ def test_collect_hostedzones(monkeypatch, fx_hosted_zones, fx_hosted_zones_expec
     route53.list_hosted_zones.return_value = fx_hosted_zones
     boto = get_boto_client(monkeypatch, route53)
 
-    res = postgresql.collect_hosted_zones(conftest.pg_infrastructure_account)
+    res = postgresql.collect_hosted_zones(conftest.pg_infrastructure_account, conftest.pg_region)
 
     assert res == fx_hosted_zones_expected
 
-    boto.assert_called_with('route53')
+    boto.assert_called_with('route53', region_name=conftest.pg_region)
 
 
 def test_collect_recordsets(monkeypatch, fx_recordsets, fx_ips_dnsnames, fx_hosted_zones_expected):
@@ -115,12 +115,12 @@ def test_collect_recordsets(monkeypatch, fx_recordsets, fx_ips_dnsnames, fx_host
     route53.get_paginator.return_value.paginate.return_value.build_full_result.return_value = fx_recordsets
     boto = get_boto_client(monkeypatch, route53)
 
-    res = postgresql.collect_recordsets(conftest.pg_infrastructure_account)
+    res = postgresql.collect_recordsets(conftest.pg_infrastructure_account, conftest.pg_region)
 
     assert res == fx_ips_dnsnames
 
     route53.get_paginator.assert_called_with('list_resource_record_sets')
-    boto.assert_called_with('route53')
+    boto.assert_called_with('route53', region_name=conftest.pg_region)
 
 
 def test_get_postgresql_clusters(

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -97,13 +97,40 @@ def test_extract_eipalloc_from_lc(fx_eip_allocation, fx_launch_configuration_exp
     assert res == fx_eip_allocation
 
 
+def test_collect_hostedzones(monkeypatch, fx_hosted_zones, fx_hosted_zones_expected):
+    route53 = MagicMock()
+    route53.list_hosted_zones.return_value = fx_hosted_zones
+    boto = get_boto_client(monkeypatch, route53)
+
+    res = postgresql.collect_hosted_zones(conftest.pg_infrastructure_account)
+
+    assert res == fx_hosted_zones_expected
+
+    boto.assert_called_with('route53')
+
+
+def test_collect_recordsets(monkeypatch, fx_recordsets, fx_ips_dnsnames, fx_hosted_zones_expected):
+    postgresql.collect_hosted_zones = MagicMock(return_value=fx_hosted_zones_expected)
+    route53 = MagicMock()
+    route53.get_paginator.return_value.paginate.return_value.build_full_result.return_value = fx_recordsets
+    boto = get_boto_client(monkeypatch, route53)
+
+    res = postgresql.collect_recordsets(conftest.pg_infrastructure_account)
+
+    assert res == fx_ips_dnsnames
+
+    route53.get_paginator.assert_called_with('list_resource_record_sets')
+    boto.assert_called_with('route53')
+
+
 def test_get_postgresql_clusters(
         fx_addresses_expected, fx_asgs_expected, fx_pg_instances_expected,
-        fx_eip_allocation, fx_launch_configuration_expected
+        fx_eip_allocation, fx_launch_configuration_expected, fx_ips_dnsnames
 ):
     postgresql.collect_eip_addresses = MagicMock(return_value=fx_addresses_expected)
     postgresql.collect_launch_configurations = MagicMock(return_value=fx_launch_configuration_expected)
     postgresql.extract_eipalloc_from_lc = MagicMock(return_value=fx_eip_allocation)
+    postgresql.collect_recordsets = MagicMock(return_value=fx_ips_dnsnames)
 
     entities = postgresql.get_postgresql_clusters(conftest.REGION, conftest.pg_infrastructure_account,
                                                   fx_asgs_expected, fx_pg_instances_expected)
@@ -121,7 +148,8 @@ def test_get_postgresql_clusters(
                                        {'instance_id': 'i-02e0',
                                         'private_ip': '192.168.1.3',
                                         'role': 'replica'}],
-                         'infrastructure_account': conftest.pg_infrastructure_account},
+                         'infrastructure_account': conftest.pg_infrastructure_account,
+                         'dnsname': 'something.interesting.com'},
                         {'type': 'postgresql_cluster',
                          'id': 'pg-malm[aws:12345678:eu-central-1]',
                          'region': conftest.REGION,
@@ -135,7 +163,8 @@ def test_get_postgresql_clusters(
                                        {'instance_id': 'i-5555',
                                         'private_ip': '192.168.31.154',
                                         'role': 'replica'}],
-                         'infrastructure_account': conftest.pg_infrastructure_account}]
+                         'infrastructure_account': conftest.pg_infrastructure_account,
+                         'dnsname': 'other.cluster.co.uk'}]
 
 
 # If any of the utility functions fail, we expect an empty list

--- a/zmon_aws_agent/postgresql.py
+++ b/zmon_aws_agent/postgresql.py
@@ -123,12 +123,14 @@ def extract_eipalloc_from_lc(launch_configuration, cluster_name):
     return user_data['environment'].get('EIP_ALLOCATION', '')
 
 
+@trace(tags={'aws': 'route53'})
 def collect_hosted_zones(infrastructure_account, region):
     r53 = boto3.client('route53', region_name=region)
     hosted_zones = r53.list_hosted_zones()  # we expect here approx. one entry
     return [hz['Id'] for hz in hosted_zones['HostedZones']]
 
 
+@trace(tags={'aws': 'route53'})
 def collect_recordsets(infrastructure_account, region):
     r53 = boto3.client('route53', region_name=region)
     hosted_zone_ids = collect_hosted_zones(infrastructure_account, region)

--- a/zmon_aws_agent/postgresql.py
+++ b/zmon_aws_agent/postgresql.py
@@ -106,6 +106,31 @@ def extract_eipalloc_from_lc(launch_configuration, cluster_name):
     return user_data['environment'].get('EIP_ALLOCATION', '')
 
 
+def collect_hosted_zones(infrastructure_account):
+    r53 = boto3.client('route53')
+    hosted_zones = r53.list_hosted_zones()  # we expect here approx. one entry
+    return [hz['Id'] for hz in hosted_zones['HostedZones']]
+
+
+def collect_recordsets(infrastructure_account):
+    r53 = boto3.client('route53')
+    hosted_zone_ids = collect_hosted_zones(infrastructure_account)
+    rs_paginator = r53.get_paginator('list_resource_record_sets')
+
+    recordsets = []
+    for hz in hosted_zone_ids:
+        recordsets = call_and_retry(
+            lambda: rs_paginator.paginate(HostedZoneId=hz).build_full_result()['ResourceRecordSets'])
+
+    ret = {}
+    for rs in recordsets:
+        if rs['Type'] == 'CNAME':
+            ip = rs['ResourceRecords'][0]['Value'].split('.')[0].replace('ec2-', '').replace('-', '.')
+            ret[ip] = rs['Name'][0:-1]  # cut off the final .
+
+    return ret
+
+
 def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
     entities = []
 
@@ -113,6 +138,7 @@ def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
         addresses = collect_eip_addresses(infrastructure_account)
         spilo_asgs = filter_asgs(infrastructure_account, asgs)
         instances = filter_instances(infrastructure_account, insts)
+        dns_records = collect_recordsets(infrastructure_account)
     except Exception:
         logger.exception('Failed to collect the AWS objects for PostgreSQL cluster detection')
         return []
@@ -125,7 +151,8 @@ def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
 
         cluster_instances = []
         eip = []
-        eip_allocation = []
+        public_ip_instance_id = ''
+        allocation_error = ''
 
         for i in cluster['instances']:
             instance_id = i['aws_id']
@@ -159,7 +186,6 @@ def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
 
                 eip_allocation = extract_eipalloc_from_lc(launch_configs, cluster_name)
 
-                public_ip_instance_id = ''
                 if eip_allocation:
                     address = [a for a in addresses if a.get('AllocationId') == eip_allocation]
                     if address:
@@ -171,7 +197,8 @@ def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
         else:
             public_ip = eip[0]['PublicIp']
             public_ip_instance_id = eip[0]['InstanceId']
-            allocation_error = ''
+
+        dnsname = dns_records.get(public_ip, '')
 
         entities.append({'type': 'postgresql_cluster',
                          'id': entity_id('pg-{}[{}:{}]'.format(cluster_name, infrastructure_account, region)),
@@ -181,6 +208,7 @@ def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
                          'elastic_ip_instance_id': public_ip_instance_id,
                          'allocation_error': allocation_error,
                          'instances': cluster_instances,
-                         'infrastructure_account': infrastructure_account})
+                         'infrastructure_account': infrastructure_account,
+                         'dnsname': dnsname})
 
     return entities


### PR DESCRIPTION
otherwise the `postgresql_database` entities won't work.  Comes with tests.