### PR TITLE
Add handle to postgres DB

### DIFF
--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -149,7 +149,8 @@ def test_get_postgresql_clusters(
                                         'private_ip': '192.168.1.3',
                                         'role': 'replica'}],
                          'infrastructure_account': conftest.pg_infrastructure_account,
-                         'dnsname': 'something.interesting.com'},
+                         'dnsname': 'something.interesting.com',
+                         'shards': {'postgres': 'something.interesting.com:5432/postgres'}},
                         {'type': 'postgresql_cluster',
                          'id': 'pg-malm[aws:12345678:eu-central-1]',
                          'region': conftest.REGION,
@@ -164,7 +165,8 @@ def test_get_postgresql_clusters(
                                         'private_ip': '192.168.31.154',
                                         'role': 'replica'}],
                          'infrastructure_account': conftest.pg_infrastructure_account,
-                         'dnsname': 'other.cluster.co.uk'}]
+                         'dnsname': 'other.cluster.co.uk',
+                         'shards': {'postgres': 'other.cluster.co.uk:5432/postgres'}}]
 
 
 # If any of the utility functions fail, we expect an empty list

--- a/zmon_aws_agent/postgresql.py
+++ b/zmon_aws_agent/postgresql.py
@@ -233,6 +233,7 @@ def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
                          'allocation_error': allocation_error,
                          'instances': cluster_instances,
                          'infrastructure_account': infrastructure_account,
-                         'dnsname': dnsname})
+                         'dnsname': dnsname,
+                         'shards': {'postgres': '{}:5432/postgres'.format(dnsname)}})
 
     return entities

--- a/zmon_aws_agent/postgresql.py
+++ b/zmon_aws_agent/postgresql.py
@@ -53,32 +53,35 @@ def get_databases_from_clusters(pgclusters, infrastructure_account, region,
                                 postgresql_user, postgresql_pass):
     entities = []
 
-    try:
-        for pg in pgclusters:
-            dnsname = pg['dnsname']
-            dbnames = list_postgres_databases(host=dnsname,
-                                              port=POSTGRESQL_DEFAULT_PORT,
-                                              user=postgresql_user,
-                                              password=postgresql_pass,
-                                              dbname='postgres',
-                                              sslmode='require')
-            for db in dbnames:
-                entity = {
-                    'id': entity_id('{}-{}[{}:{}]'.format(db, dnsname, infrastructure_account, region)),
-                    'type': 'postgresql_database',
-                    'created_by': 'agent',
-                    'infrastructure_account': infrastructure_account,
-                    'region': region,
+    for pg in pgclusters:
+        try:
+            dnsname = pg.get('dnsname')
 
-                    'postgresql_cluster': pg['id'],
-                    'database_name': db,
-                    'shards': {
-                        db: '{}:{}/{}'.format(dnsname, POSTGRESQL_DEFAULT_PORT, db)
+            if dnsname:
+                dbnames = list_postgres_databases(host=dnsname,
+                                                  port=POSTGRESQL_DEFAULT_PORT,
+                                                  user=postgresql_user,
+                                                  password=postgresql_pass,
+                                                  dbname='postgres',
+                                                  sslmode='require')
+                for db in dbnames:
+                    entity = {
+                        'id': entity_id('{}-{}[{}:{}]'.format(db, dnsname, infrastructure_account, region)),
+                        'type': 'postgresql_database',
+                        'created_by': 'agent',
+                        'infrastructure_account': infrastructure_account,
+                        'region': region,
+
+                        'postgresql_cluster': pg.get('id'),
+                        'database_name': db,
+                        'shards': {
+                            db: '{}:{}/{}'.format(dnsname, POSTGRESQL_DEFAULT_PORT, db)
+                        }
                     }
-                }
-                entities.append(entity)
-    except Exception:
-        logger.exception("Failed to make Database entities for PostgreSQL clusters!")
+                    entities.append(entity)
+        except Exception:
+            logger.exception('Failed to make Database entities for PostgreSQL clusters on {}!'
+                             .format(pg.get('dnsname', '')))
 
     return entities
 
@@ -90,16 +93,15 @@ def collect_eip_addresses(infrastructure_account, region):
     addresses = call_and_retry(ec2.describe_addresses)['Addresses']
 
     return [a for a in addresses if a['NetworkInterfaceOwnerId'] == infrastructure_account.split(':')[1]]
-# FIXME: depend on region, too?
 
 
 def filter_asgs(infrastructure_account, asgs):
     return [gr for gr in asgs
-            if gr['infrastructure_account'] == infrastructure_account and 'spilo_cluster' in gr.keys()]
+            if gr.get('infrastructure_account') == infrastructure_account and 'spilo_cluster' in gr.keys()]
 
 
 def filter_instances(infrastructure_account, instances):
-    return [i for i in instances if i['infrastructure_account'] == infrastructure_account]
+    return [i for i in instances if i.get('infrastructure_account') == infrastructure_account]
 
 
 @trace(tags={'aws': 'asg'})


### PR DESCRIPTION
This was somehow forgotten when first adding the cluster discovery.  In the manually created entities it's there, and that results in situations where two entities of the same thing report different things (an error and the expected values, respectively).