### PR TITLE
Add created_by to postgresql_cluster

### DIFF
--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -137,6 +137,7 @@ def test_get_postgresql_clusters(
 
     assert entities == [{'type': 'postgresql_cluster',
                          'id': 'pg-bla[aws:12345678:eu-central-1]',
+                         'created_by': 'agent',
                          'region': conftest.REGION,
                          'spilo_cluster': 'bla',
                          'elastic_ip': '12.23.34.45',
@@ -153,6 +154,7 @@ def test_get_postgresql_clusters(
                          'shards': {'postgres': 'something.interesting.com:5432/postgres'}},
                         {'type': 'postgresql_cluster',
                          'id': 'pg-malm[aws:12345678:eu-central-1]',
+                         'created_by': 'agent',
                          'region': conftest.REGION,
                          'spilo_cluster': 'malm',
                          'elastic_ip': '22.33.44.55',

--- a/zmon_aws_agent/postgresql.py
+++ b/zmon_aws_agent/postgresql.py
@@ -231,6 +231,7 @@ def get_postgresql_clusters(region, infrastructure_account, asgs, insts):
 
         entities.append({'type': 'postgresql_cluster',
                          'id': entity_id('pg-{}[{}:{}]'.format(cluster_name, infrastructure_account, region)),
+                         'created_by': 'agent',
                          'region': region,
                          'spilo_cluster': cluster_name,
                          'elastic_ip': public_ip,


### PR DESCRIPTION
The field is missing, and therefore old entities are not cleaned up.