### PR TITLE
fix uppercase only names

### DIFF
--- a/zmon_aws_agent/aws.py
+++ b/zmon_aws_agent/aws.py
@@ -292,7 +292,8 @@ def get_running_apps(region, existing_entities=None, **kwargs):
                         ins['fluentd_enabled'] = 'true'
 
                 else:
-                    ins['id'] = entity_id('{}-{}[aws:{}:{}]'.format(tags.get('Name') or i['InstanceId'],
+                    name = tags.get('Name') or i['InstanceId']
+                    ins['id'] = entity_id('{}-{}[aws:{}:{}]'.format(name.lower(),
                                                                     get_hash(i['PrivateIpAddress'] + ''),
                                                                     owner, region))
 


### PR DESCRIPTION
this prevents entities being created with just "$IPHASH[aws:$ACCOUNT_ID:$REGION]" as id